### PR TITLE
都道府県の判別処理を修正

### DIFF
--- a/src/views/map/index.tsx
+++ b/src/views/map/index.tsx
@@ -22,7 +22,7 @@ const createDepotsDataList = (statsData: StatData[], prefsData: PrefData[]): Dep
     statsData.forEach((statData) => {
         let prefData: PrefData = { Longitude: 0, Latitude: 0, NameEn: "", NameJa: "", Id: 0, Regions: "" }
         prefsData.forEach((pref) => {
-            if (pref.NameJa === statData.Prefecture) {
+            if (statData.Prefecture.indexOf(pref.NameJa) !== -1) {
                 prefData = pref
             }
         })


### PR DESCRIPTION
都道府県名が、
- statsData では 大阪*府* や 愛知*県* まで含む
- prefsData では 大阪 や 愛知 で終わっている

ので、一致判定では北海道のみ正常に判別されていた模様です。