### PR TITLE
地図上に点が表示されるように修正

### DIFF
--- a/src/types/data.ts
+++ b/src/types/data.ts
@@ -12,8 +12,8 @@ export interface PrefData {
     NameJa: string,
     NameEn: string,
     Regions: string,
-    Latitude: number,
-    Longitude: number,
+    Latitude: string,
+    Longitude: string,
 }
 
 export interface TotalData {

--- a/src/views/map/index.tsx
+++ b/src/views/map/index.tsx
@@ -20,14 +20,14 @@ const createDepotsDataList = (statsData: StatData[], prefsData: PrefData[]): Dep
     const lastDate = statsData[statsData.length - 1].Date
 
     statsData.forEach((statData) => {
-        let prefData: PrefData = { Longitude: 0, Latitude: 0, NameEn: "", NameJa: "", Id: 0, Regions: "" }
+        let prefData: PrefData = { Longitude: "0", Latitude: "0", NameEn: "", NameJa: "", Id: 0, Regions: "" }
         prefsData.forEach((pref) => {
             if (statData.Prefecture.indexOf(pref.NameJa) !== -1) {
                 prefData = pref
             }
         })
         if (statData.Date === lastDate) {
-            dataList = dataList.concat(Array.from({ length: statData.TotalCases }, (): DepotsData => createDepotsData(prefData.Longitude, prefData.Latitude)))
+            dataList = dataList.concat(Array.from({ length: statData.TotalCases }, (): DepotsData => createDepotsData(parseFloat(prefData.Longitude), parseFloat(prefData.Latitude))))
         }
     })
 


### PR DESCRIPTION
TypeScript 上では型定義に従ってコンパイルされるが、実際には JavaScript なため、以下のような現象が起こっていました：

- 理想的な動作：
  JSON レベルで PrefData の Lat. と Lon. が number 型のデータで、createDepotsData では float + float の計算で float が出力される
- 本来型エラーで止まってほしい動作：
  そもそも prefecture の JSON では、 Lat. と Lon. が string 型なので、パースできずにエラーになるはず
- JSだから：
  型を気にしないので↑のJSONが読み込めてしまい処理続行
- 結局：
  createDepotsData で string + float が行われて、string 型になる
  ⇒ Harmoware-VIS で正常に読み込めなくなっていた (0かとても大きい数字とでも解釈されていたのでしょうか…。)

このプルリクエストの通りに修正したら、マップに点が出ました。
![image](https://user-images.githubusercontent.com/38305549/78543469-a8454a80-7833-11ea-9867-125cc7e36e35.png)
